### PR TITLE
Event listener refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
     - "0.10"
-

--- a/lib/application.js
+++ b/lib/application.js
@@ -111,6 +111,44 @@ Box.Application = (function() {
 	}
 
 	/**
+	 * Abstract addEventListener for better IE8 support
+	 * also avoid direct dependency on jQuery, but keep it as the default choice
+	 * @param {HTMLElement} element DOM element to bind the event to
+	 * @param {string} type Event type (click, mouseover, ...)
+	 * @param {Function[]} handlers Array of event callbacks to be called in that order
+	 * @returns {void}
+	 * @private
+	 */
+	function addListener(element, type, handlers) {
+		if ('$' in window && typeof $ === 'function') {
+			$(element).on(type, handlers);
+			return;
+		}
+
+		// assumes single event type
+		element.addEventListener(type, handlers, false);
+	}
+
+	/**
+	 * Abstract removeEventListener for better IE8 support
+	 * also avoid direct dependency on jQuery, but keep it as the default choice
+	 * @param {HTMLElement} element DOM element to bind the event to
+	 * @param {string} type Event type (click, mouseover, ...)
+	 * @param {Function[]} handlers Array of event callbacks to be called in that order
+	 * @returns {void}
+	 * @private
+	 */
+	function removeListener(element, type, handlers) {
+		if ('$' in window && typeof $ === 'function') {
+			$(element).off(type, handlers);
+			return;
+		}
+
+		// assumes single event type
+		element.removeEventListener(type, handlers, false);
+	}
+
+	/**
 	 * Reset all state to its default values
 	 * @returns {void}
 	 * @private
@@ -374,8 +412,7 @@ Box.Application = (function() {
 			return true;
 		}
 
-		// @NOTE(nzakas): Using jQuery for event normalization
-		$(element).on(type, eventHandler);
+		addListener(element, type, eventHandler);
 
 		return eventHandler;
 	}
@@ -427,8 +464,7 @@ Box.Application = (function() {
 	function unbindEventListeners(instanceData) {
 		for (var type in instanceData.eventHandlers) {
 			if (instanceData.eventHandlers.hasOwnProperty(type)) {
-				// @NOTE(nzakas): Using jQuery for event normalization
-				$(instanceData.element).off(type, instanceData.eventHandlers[type]);
+				removeListener(instanceData.element, type, instanceData.eventHandlers[type]);
 			}
 		}
 

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -7,11 +7,19 @@ describe('Box.Application', function() {
 
 	'use strict';
 
+	var $ = jQuery.noConflict(true);
 	var sandbox = sinon.sandbox.create();
 
 	var testModule,
 		testModule2,
-		nestedModule;
+		nestedModule,
+		customEvent;
+
+	var dispatch = function(selector) {
+		customEvent = document.createEvent('MouseEvent');
+		customEvent.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 1, null);
+		$(selector)[0].dispatchEvent(customEvent);
+	};
 
 	before(function() {
 		var fixture = document.createElement('div');
@@ -480,10 +488,22 @@ describe('Box.Application', function() {
 
 			Box.Application.start(testModule);
 
+			dispatch('#module-target');
+		});
+
+		it('should be called when an event occurs inside of a started module, using jQuery', function() {
+			window.$ = $;
+			Box.Application.addModule('test', sandbox.stub().returns({
+				onclick: sandbox.mock()
+			}));
+
+			Box.Application.start(testModule);
+
 			$('#module-target').trigger({
 				type: 'click',
 				button: 1
 			});
+			window.$ = undefined;
 		});
 
 		it('should be called on behaviors in correct order when defined', function() {
@@ -506,10 +526,7 @@ describe('Box.Application', function() {
 
 			Box.Application.start(testModule);
 
-			$('#module-target').trigger({
-				type: 'click',
-				button: 1
-			});
+			dispatch('#module-target');
 
 			assert.ok(moduleClickSpy.calledBefore(behaviorClickSpy), 'module called before first behavior');
 			assert.ok(behaviorClickSpy.calledBefore(behavior2ClickSpy), 'first behavior called before second behavior');
@@ -524,10 +541,7 @@ describe('Box.Application', function() {
 
 			Box.Application.start(testModule);
 
-			$('#module-target').trigger({
-				type: 'click',
-				button: 1
-			});
+			dispatch('#module-target');
 
 		});
 
@@ -546,10 +560,7 @@ describe('Box.Application', function() {
 
 			Box.Application.start(moduleWithDataTypeOutside.firstChild);
 
-			$('#inner-btn').trigger({
-				type: 'click',
-				button: 1
-			});
+			dispatch('#inner-btn');
 
 		});
 
@@ -562,16 +573,12 @@ describe('Box.Application', function() {
 			Box.Application.start(testModule);
 			Box.Application.stop(testModule);
 
-			$('#module-target').trigger({
-				type: 'click',
-				button: 1
-			});
+			dispatch('#module-target');
 
 		});
 
 
 	});
-
 
 	describe('broadcast()', function() {
 


### PR DESCRIPTION
Address issues raised in #12, especially strong jQuery dependency.

Box team might have bigger fish to fry, so open a pull request here to signal someone is working on it.

----

Now it works, I end up doing following changes:

1. Abstract event system into `addListener` and `removeListener`, still prefer jQuery over native `add/removeEventListener`, but allow seamless fallback.

2. Update karma config and use `mocha` reporter instead of `progress`, this is good because `progress` does not show which test fails when you do `sandbox.verifyAndRestore` in `afterEach`; though generally one should avoid assert (`sandbox.verify` is implied assert) in `afterEach` because it cause mocha to abort all subsequent tests.

3. Update test cases so that it no longer depends on jQuery in global space, by `jQuery.noConflict` at the start. Note that we still test for jQuery global, see tests for `on[event]()`

4. Update travis to include node v0.12 and latest iojs