### PR TITLE
Update event-target.js

### DIFF
--- a/lib/event-target.js
+++ b/lib/event-target.js
@@ -104,8 +104,8 @@ Box.EventTarget = (function() {
 			this._handlers[type] = remainingHandlers;
 			
 			if (this._handlers[type].length === 0) {
-+		        	delete this._handlers[type];
-+		        }
+		        	delete this._handlers[type];
+		        }
 		}
 	};
 

--- a/lib/event-target.js
+++ b/lib/event-target.js
@@ -24,6 +24,10 @@ Box.EventTarget = (function() {
 		 */
 		this._handlers = {};
 	}
+	
+	function isArray(argument) {
+		return Object.prototype.toString.call(argument) === '[object Array]';
+	}
 
 	EventTarget.prototype = {
 
@@ -52,7 +56,6 @@ Box.EventTarget = (function() {
 		 * @returns {void}
 		 */
 		fire: function(type, data) {
-
 			var handlers,
 				i,
 				len,
@@ -63,14 +66,16 @@ Box.EventTarget = (function() {
 
 			// if there are handlers for the event, call them in order
 			handlers = this._handlers[event.type];
-			if (handlers instanceof Array) {
-				// @NOTE: do a concat() here to create a copy of the handlers array,
-				// so that if another handler is removed of the same type, it doesn't
-				// interfere with the handlers array during this loop
-				handlers = handlers.concat();
-				for (i = 0, len = handlers.length; i < len; i++) {
-					handlers[i].call(this, event);
-				}
+			if (!isArray(handlers)) {
+				return;
+			}
+
+			// @NOTE: do a concat() here to create a copy of the handlers array,
+			// so that if another handler is removed of the same type, it doesn't
+			// interfere with the handlers array during this loop
+			handlers = handlers.concat();
+			for (i = 0, len = handlers.length; i < len; i++) {
+				handlers[i].call(this, event);
 			}
 		},
 
@@ -81,19 +86,26 @@ Box.EventTarget = (function() {
 		 * @returns {void}
 		 */
 		off: function(type, handler) {
-
 			var handlers = this._handlers[type],
 				i,
-				len;
+				len,
+				remainingHandlers = [];
 
-			if (handlers instanceof Array) {
-				for (i = 0, len = handlers.length; i < len; i++) {
-					if (handlers[i] === handler) {
-						handlers.splice(i, 1);
-						break;
-					}
+			if (!isArray(handlers)) {
+				return;
+			}
+
+			for (i = 0, len = handlers.length; i < len; i++) {
+				if (handlers[i] !== handler) {
+					remainingHandlers.push(handler);
 				}
 			}
+			
+			this._handlers[type] = remainingHandlers;
+			
+			if (this._handlers[type].length === 0) {
++		        	delete this._handlers[type];
++		        }
 		}
 	};
 


### PR DESCRIPTION
Created function isArray is faster than instanceof Array (http://stackoverflow.com/questions/22289727/difference-between-using-array-isarray-and-instanceof-array). For avoid indents use guard clause and end work for functions earlier. If you do not want to use filter, you can use own implementation (visible in pull request). And as previously when array is empty we remove the type key from handlers.