### PR TITLE
Fix learn more link positioning (fixes #70)

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -14,7 +14,8 @@
             <a class="button cta margin-top-25" href="{{ site.baseurl }}/download">Download T3</a>
         </div>
     </div>
-</div>
-<div id="learn-more" class="row text-center">
-    <a href="#core-philosophy">Learn More<br />&darr;</a>
+
+    <div id="learn-more" class="row text-center">
+        <a href="#core-philosophy">Learn More<br />&darr;</a>
+    </div>
 </div>

--- a/css/main.css
+++ b/css/main.css
@@ -84,8 +84,7 @@
 }
 
 #learn-more {
-	position: relative;
-	top: -200px;
+	margin-top: 40px;
 }
 
 #learn-more a:hover {


### PR DESCRIPTION
This PR moves the **Learn More** link into the hero section and replaces the relative positioning with a `margin-top`. This means that the link will be appropriately spaced from the **Download** button regardless of how the intro text wraps.

**Before**: http://quick.as/5agvi5el0

**After**: http://quick.as/o0gwc6nbp

Fixes #70 