### PR TITLE
Add support for broadcast in module init function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -668,7 +668,7 @@ Box.Application = (function() {
 				creator: creator,
 				counter: 1 // increments for each new instance
 			};
-			moduleMessages[moduleName] = creator().messages || [];
+			moduleMessages[moduleName] = creator({}).messages || [];
 		},
 
 		/**

--- a/lib/application.js
+++ b/lib/application.js
@@ -47,6 +47,7 @@ Box.Application = (function() {
 
 	var globalConfig = {},   // Global configuration
 		modules = {},        // Information about each registered module by moduleName
+		moduleMessages = {}, // Information about each registered module's listening messages
 		serviceStack = [],   // Track circular dependencies while loading services
 		services = {},       // Information about each registered service by serviceName
 		behaviors = {},      // Information about each registered behavior by behaviorName
@@ -234,6 +235,16 @@ Box.Application = (function() {
 		}
 		return '';
 	}
+	
+	/**
+         * Returns the DOM element associated with the specific T3 module name
+         * @param {string} moduleName The name of T3 module
+         * @returns {HTMLElement} element DOM element associated with the module
+         * @private
+         */
+        function getElementByModuleName(moduleName) {
+            return document.querySelector(MODULE_SELECTOR.split("]")[0] + "=" + moduleName + "]");
+        }
 
 	/**
 	 * Determines if a given element represents a module.
@@ -269,6 +280,22 @@ Box.Application = (function() {
 			instance[method].apply(instance, Array.prototype.slice.call(arguments, 2));
 		}
 	}
+	
+	/**
+         * Determines if a given module has been instantiated
+         * @param {string} moduleName The name of T3 module
+         * @returns {boolean} True if the module already instantiated, false if not.
+         * @private
+         */
+        function isMouduleInstantiated(moduleName) {
+            var i;
+            for(i in instances) {
+                if(instances[i]['moduleName'] === moduleName) {
+                    return true;
+                }
+            }
+            return false;
+        }
 
 	/**
 	 * Returns the requested service
@@ -641,6 +668,7 @@ Box.Application = (function() {
 				creator: creator,
 				counter: 1 // increments for each new instance
 			};
+			moduleMessages[moduleName] = creator()["messages"] || [];
 		},
 
 		/**
@@ -786,11 +814,21 @@ Box.Application = (function() {
 		 */
 		broadcast: function(name, data) {
 			var i,
-				id,
-				instanceData,
-				behaviorInstance,
-				moduleBehaviors,
-				messageHandlers;
+			id,
+			instanceData,
+			behaviorInstance,
+			moduleBehaviors,
+			messageHandlers,
+                    	moduleName,
+                    	messageNames,
+                    	moduleElement;
+
+                	for(moduleName in moduleMessages) {
+
+                    		if(indexOf(moduleMessages[moduleName] || [], name) !== -1 && !isMouduleInstantiated(moduleName) ) {
+                        		this.start(getElementByModuleName(moduleName));
+                    		}
+                	}
 
 			for (id in instances) {
 


### PR DESCRIPTION
Problem:
I cannot use the 'context.broadcast' to notice another module what happens when I do something in the init part of current module.
Solution:
When one module added to framework, record the message list for it. And when broadcast called, firstly, check if the message handler module already instantiated, if not, instantiate it immediately