### PR TITLE
Breaking: Use NativeDOM by default (fixes #76)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -31,7 +31,6 @@ var NODE = 'node ',	// intentional extra space
 
 	// Utilities - intentional extra space at the end of each string
 	ISTANBUL = NODE + NODE_MODULES + 'istanbul/lib/cli.js ',
-	MOCHA = NODE_MODULES + 'mocha/bin/_mocha ',
 	JSDOC = NODE + NODE_MODULES + 'jsdoc/jsdoc.js ',
 
 	// Since our npm package name is actually 't3js'
@@ -232,6 +231,19 @@ target.test = function() {
 	if (code !== 0) {
 		exit(code);
 	}
+
+	echo('Running API tests');
+	target['api-test']();
+};
+
+target['api-test'] = function() {
+	// generate dist files that are used by api-test
+	target.dist();
+
+	nodeExec('mocha', './tests/api-test.js');
+
+	// revert generated files
+	execOrExit('git checkout dist');
 };
 
 target['test-watch'] = function() {
@@ -301,8 +313,8 @@ target.dist = function() {
 		testingFiles: TESTING_JQUERY_FILES
 	}, {
 		name: DIST_NAME,
-		files: SRC_JQUERY_FILES,
-		testingFiles: TESTING_JQUERY_FILES
+		files: SRC_NATIVE_FILES,
+		testingFiles: TESTING_NATIVE_FILES
 	}].forEach(function(dist){
 		generateDistFiles(dist);
 	});

--- a/config/karma-conf.js
+++ b/config/karma-conf.js
@@ -46,6 +46,7 @@ module.exports = function(config) {
 
 		// list of files to exclude
 		exclude: [
+			'tests/api-test.js'
 		],
 
 		// preprocess matching files before serving them to the browser

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "minor": "node Makefile.js minor",
     "major": "node Makefile.js major"
   },
-  "main": "dist/t3.js",
+  "main": "dist/t3-native.js",
   "devDependencies": {
     "assertive-chai": "^1.0.2",
     "dateformat": "^1.0.11",

--- a/tests/api-test.js
+++ b/tests/api-test.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Tests for T3 API (package.json and dist files)
+ * @author Box
+ */
+
+'use strict';
+
+// @NOTE(nzakas): This file runs in Node.js, not Karma!
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require('assertive-chai').assert,
+	leche = require('leche'),
+	path = require('path'),
+	defaultT3 = require('../dist/t3'),
+	nativeT3 = require('../dist/t3-native'),
+	jqueryT3 = require('../dist/t3-jquery'),
+	pkg = require('../package.json');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe('API', function() {
+
+	describe('Defaults', function() {
+		it('should use native DOM in default file', function() {
+			assert.equal(defaultT3.DOM.type, 'native');
+		});
+
+		it('should use native DOM in native file', function() {
+			assert.equal(nativeT3.DOM.type, 'native');
+		});
+
+		it('should use jQuery DOM in jQuery file', function() {
+			assert.equal(jqueryT3.DOM.type, 'jquery');
+		});
+	});
+
+	describe('Exports', function() {
+
+		leche.withData({
+			'Default T3': defaultT3,
+			'Native T3': nativeT3,
+			'jQuery T3': jqueryT3
+		}, function(T3) {
+
+			leche.withData([
+				'DOM',
+				'DOMEventDelegate',
+				'EventTarget',
+				'Application',
+				'Context'
+			], function(name) {
+				it('should have Box.' + name, function() {
+					assert.isDefined(T3[name]);
+				});
+			});
+
+		});
+
+	});
+
+	describe('package.json', function() {
+
+		it('should export native T3', function() {
+			assert.equal(require(path.join('../', pkg.main)), nativeT3);
+		});
+
+	});
+
+});


### PR DESCRIPTION
Switches the default JS file to be native instead of jQuery (both in `dist` and for `package.json`).

Also, added tests of the API to verify the change is correct and to avoid situations like the great missing `DOMEventDelegate` caper.