### PR TITLE
Bind event handlers after init() is called

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -475,8 +475,6 @@ Box.Application = (function() {
 					eventDelegates: []
 				};
 
-				bindEventListeners(instanceData);
-
 				instances[element.id] = instanceData;
 
 				callModuleMethod(instanceData.instance, 'init');
@@ -488,6 +486,8 @@ Box.Application = (function() {
 					behaviorInstance = moduleBehaviors[i];
 					callModuleMethod(behaviorInstance, 'init');
 				}
+
+				bindEventListeners(instanceData);
 
 			}
 

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -133,6 +133,18 @@ describe('Box.Application', function() {
 				Box.Application.start(testModule);
 			});
 
+			it('should call init() on module before binding event handlers when called', function() {
+				Box.Application.addModule('test', function() {
+					return {
+						init: function() {
+							document.getElementById('module-target').click();
+						},
+						onclick: sandbox.mock().never()
+					};
+				});
+				Box.Application.start(testModule);
+			});
+
 			it('should call init() on module and behaviors in order they are defined when called', function() {
 				var moduleInitSpy = sandbox.spy(),
 					behaviorInitSpy = sandbox.spy(),


### PR DESCRIPTION
- fixing a timing issues that was caused by events firing while initializing modules

fixes #100