### PR TITLE
Breaking: Initialize behaviors before module

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -491,8 +491,6 @@ Box.Application = (function() {
 
 				instances[element.id] = instanceData;
 
-				callModuleMethod(instanceData.instance, 'init');
-
 				var moduleBehaviors = getBehaviors(instanceData),
 					behaviorInstance;
 
@@ -501,6 +499,10 @@ Box.Application = (function() {
 					callModuleMethod(behaviorInstance, 'init');
 				}
 
+				// Initialize module only after behaviors are initialized
+				callModuleMethod(instanceData.instance, 'init');
+
+				// Bind events after initialization is complete to avoid event timing issues
 				bindEventListeners(instanceData);
 
 			}

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -145,7 +145,7 @@ describe('Box.Application', function() {
 				Box.Application.start(testModule);
 			});
 
-			it('should call init() on module and behaviors in order they are defined when called', function() {
+			it('should call init() behaviors in order they are defined and then the module when called', function() {
 				var moduleInitSpy = sandbox.spy(),
 					behaviorInitSpy = sandbox.spy(),
 					behavior2InitSpy = sandbox.spy();
@@ -162,8 +162,9 @@ describe('Box.Application', function() {
 				}));
 				Box.Application.start(testModule);
 
-				assert.ok(moduleInitSpy.calledBefore(behaviorInitSpy), 'module init called before first behavior init');
 				assert.ok(behaviorInitSpy.calledBefore(behavior2InitSpy), 'first behavior init called before second behavior init');
+				assert.ok(behavior2InitSpy.calledBefore(moduleInitSpy), 'module init called after second behavior init');
+
 			});
 
 			it('should emit an error event when not in debug mode', function() {


### PR DESCRIPTION
- Module init should expect all pre-requisites to be fulfilled before it can successfully initialize

fixes #107