### PR TITLE
Add malformed JSON error message

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -616,7 +616,11 @@ Box.Application = (function() {
 
 				// <script> tag supports .text property
 				if (configElement) {
-					moduleConfig = JSON.parse(configElement.text);
+					try {
+						moduleConfig = JSON.parse(configElement.text);
+					} catch (exception) {
+						error(new Error('Module with id ' + element.id + ' has a malformed config.'));
+					}
 				}
 
 				// Cache the configurations for performance, if the module instance has been created


### PR DESCRIPTION
This enhancement aims to add a better error message around a malformed x-config string. Our tech stack doesn't always put us in the position where we can generate our client side JSON and we've had a lot of confusion around the errors that crop up because of malformed JSON.

Feel free to suggest enhancements or alternatives.