### PR TITLE
Correct the context.getConfig documentation

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -47,11 +47,6 @@ This method is a proxy to <a href="../application/#getModuleConfig">Application.
 	</thead>
 	<tbody>
 		<tr>
-			<td class="required">element</td>
-			<td>HTMLElement</td>
-			<td>Module root element.</td>
-		</tr>
-		<tr>
 			<td class="optional">name</td>
 			<td>string</td>
 			<td>Specific configuration value to retrieve.</td>


### PR DESCRIPTION
The context.getConfig documentation mirroring application.getModuleConfig by saying that it allowed an element. This is not the case.

This PR addresses #157.