### PR TITLE
Support cleaner onmessage handler

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -74,20 +74,6 @@ Box.Application = (function() {
 	}
 
 	/**
-	 * Creates a new version of a function whose this-value is bound to a specific
-	 * object.
-	 * @param {Function} method The function to bind.
-	 * @param {Object} thisValue The this-value to set for the function.
-	 * @returns {Function} A bound version of the function.
-	 * @private
-	 */
-	function bind(method, thisValue) {
-		return function() {
-			return method.apply(thisValue, arguments);
-		};
-	}
-
-	/**
 	 * Simple implementation of Array.prototype.indexOf().
 	 * @param {*[]} items An array of items to search.
 	 * @param {*} item The item to search for in the array.

--- a/lib/application.js
+++ b/lib/application.js
@@ -385,6 +385,26 @@ Box.Application = (function() {
 		return instances[element.id];
 	}
 
+	/**
+	 * Gets message handlers from the provided module instance
+	 * @param {Box.Application~ModuleInstance|Box.Application~BehaviorInstance} instance Messages handlers will be retrieved from the Instance object
+	 * @param {String} name The name of the message to be handled
+   * @param {Any} data A playload to be passed to the message handler
+	 * @returns {void}
+	 * @private
+	 */
+	function callMessageHandler(instance, name, data) {
+
+		// If onmessage is an object call message handler with the matching key (if any)
+		if (instance.onmessage !== null && typeof instance.onmessage === 'object' && instance.onmessage.hasOwnProperty(name)) {
+			bind(instance.onmessage[name], instance)(data);
+
+		// Otherwise if message name exists in messages call onmessage with name, data
+		} else if (indexOf(instance.messages || [], name) !== -1) {
+			bind(instance.onmessage, instance)(name, data);
+		}
+	}
+
 	//--------------------------------------------------------------------------
 	// Public
 	//--------------------------------------------------------------------------
@@ -719,32 +739,21 @@ Box.Application = (function() {
 				id,
 				instanceData,
 				behaviorInstance,
-				moduleBehaviors,
-				messageHandlers;
+				moduleBehaviors;
 
 			for (id in instances) {
 
 				if (instances.hasOwnProperty(id)) {
-					messageHandlers = [];
 					instanceData = instances[id];
 
 					// Module message handler is called first
-					if (indexOf(instanceData.instance.messages || [], name) !== -1) {
-						messageHandlers.push(bind(instanceData.instance.onmessage, instanceData.instance));
-					}
+					callMessageHandler(instanceData.instance, name, data);
 
 					// And then any message handlers defined in module's behaviors
 					moduleBehaviors = getBehaviors(instanceData);
 					for (i = 0; i < moduleBehaviors.length; i++) {
 						behaviorInstance = moduleBehaviors[i];
-
-						if (indexOf(behaviorInstance.messages || [], name) !== -1) {
-							messageHandlers.push(bind(behaviorInstance.onmessage, behaviorInstance));
-						}
-					}
-
-					for (i = 0; i < messageHandlers.length; i++) {
-						messageHandlers[i](name, data);
+						callMessageHandler(behaviorInstance, name, data);
 					}
 				}
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -397,11 +397,11 @@ Box.Application = (function() {
 
 		// If onmessage is an object call message handler with the matching key (if any)
 		if (instance.onmessage !== null && typeof instance.onmessage === 'object' && instance.onmessage.hasOwnProperty(name)) {
-			bind(instance.onmessage[name], instance)(data);
+			instance.onmessage[name](data);
 
 		// Otherwise if message name exists in messages call onmessage with name, data
 		} else if (indexOf(instance.messages || [], name) !== -1) {
-			bind(instance.onmessage, instance)(name, data);
+			instance.onmessage(name, data);
 		}
 	}
 

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -754,7 +754,7 @@ describe('Box.Application', function() {
 				Box.Application.broadcast('abc', messageData);
 			});
 
-			it('should call handler of onmessage object', function() {
+			it('should use correct handler of onmessage object when called', function() {
 				var messageData = {};
 				Box.Application.addModule('test', sandbox.stub().returns({
 					onmessage: {

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -562,8 +562,8 @@ describe('Box.Application', function() {
 
 			it('should still be called with a null element when an event occurs on a recently detached element', function() {
 				// Background on this edge case:
-				//  1. event handlers like mouseout may sometimes detach nodes from the DOM
-				//  2. event handlers like mouseleave will still fire on the detached node
+				//	1. event handlers like mouseout may sometimes detach nodes from the DOM
+				//	2. event handlers like mouseleave will still fire on the detached node
 				// Without checking the existence of a parentNode and returning null, we would throw errors
 
 				// Scenario appears unique to jquery
@@ -750,6 +750,18 @@ describe('Box.Application', function() {
 				}));
 				Box.Application.start(testModule);
 				Box.Application.start(testModule2);
+
+				Box.Application.broadcast('abc', messageData);
+			});
+
+			it('should call handler of onmessage object', function() {
+				var messageData = {};
+				Box.Application.addModule('test', sandbox.stub().returns({
+					onmessage: {
+						'abc': sandbox.mock().withArgs(messageData)
+					}
+				}));
+				Box.Application.start(testModule);
 
 				Box.Application.broadcast('abc', messageData);
 			});

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -754,7 +754,7 @@ describe('Box.Application', function() {
 				Box.Application.broadcast('abc', messageData);
 			});
 
-			it('should use correct handler of onmessage object when called', function() {
+			it('should call corresponding message handler when a message is received', function() {
 				var messageData = {};
 				Box.Application.addModule('test', sandbox.stub().returns({
 					onmessage: {


### PR DESCRIPTION
This change allows onmessage to be an object with its children being a key, value pair that corresponds to a message and its handler. This eliminates the need for a switch statement.

This PR addresses #145.