### PR TITLE
Fix the message handler context to be the behavior or module instance

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -383,11 +383,11 @@ Box.Application = (function() {
 
 		// If onmessage is an object call message handler with the matching key (if any)
 		if (instance.onmessage !== null && typeof instance.onmessage === 'object' && instance.onmessage.hasOwnProperty(name)) {
-			instance.onmessage[name](data);
+			instance.onmessage[name].call(instance, data);
 
 		// Otherwise if message name exists in messages call onmessage with name, data
 		} else if (indexOf(instance.messages || [], name) !== -1) {
-			instance.onmessage(name, data);
+			instance.onmessage.call(instance, name, data);
 		}
 	}
 

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -766,6 +766,19 @@ describe('Box.Application', function() {
 				Box.Application.broadcast('abc', messageData);
 			});
 
+			it('should provide the instance of the module or behavior to the message handler when a message is received', function() {
+				Box.Application.addModule('test', sandbox.stub().returns({
+					onmessage: {
+						'abc': function() {
+							assert.isTrue(this.onmessage !== undefined);
+						}
+					}
+				}));
+				Box.Application.start(testModule);
+
+				Box.Application.broadcast('abc');
+			});
+
 			it('should call onmessage of behaviors listening in correct order when defined', function() {
 				var messageData = {},
 					moduleMessageSpy = sandbox.spy(),


### PR DESCRIPTION
As noted in #160 we forgot to set the context of the handler to be that of the instance. Without this change #145 could potentially break things for pre-2.2.0 versions that relied on that context to be preserved. 