### PR TITLE
Add custom event types

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -320,7 +320,7 @@ Box.Application = (function() {
 	 * @private
 	 */
 	function createAndBindEventDelegate(eventDelegates, element, handler) {
-		var delegate = new Box.DOMEventDelegate(element, handler);
+		var delegate = new Box.DOMEventDelegate(element, handler, globalConfig.eventTypes);
 		eventDelegates.push(delegate);
 		delegate.attachEvents();
 	}

--- a/lib/dom-event-delegate.js
+++ b/lib/dom-event-delegate.js
@@ -9,7 +9,7 @@ Box.DOMEventDelegate = (function() {
 	'use strict';
 
 	// Supported events for modules. Only events that bubble properly can be used in T3.
-	var EVENT_TYPES = ['click', 'mouseover', 'mouseout', 'mousedown', 'mouseup',
+	var DEFAULT_EVENT_TYPES = ['click', 'mouseover', 'mouseout', 'mousedown', 'mouseup',
 			'mouseenter', 'mouseleave', 'mousemove', 'keydown', 'keyup', 'submit', 'change',
 			'contextmenu', 'dblclick', 'input', 'focusin', 'focusout'];
 
@@ -62,19 +62,20 @@ Box.DOMEventDelegate = (function() {
 	/**
 	 * Iterates over each supported event type that is also in the handler, applying
 	 * a callback function. This is used to more easily attach/detach all events.
+	 * @param {string[]} eventTypes A list of event types to iterate over
 	 * @param {Object} handler An object with onclick, onmouseover, etc. methods.
 	 * @param {Function} callback The function to call on each event type.
 	 * @param {Object} [thisValue] The value of "this" inside the callback.
 	 * @returns {void}
 	 * @private
 	 */
-	function forEachEventType(handler, callback, thisValue) {
+	function forEachEventType(eventTypes, handler, callback, thisValue) {
 
 		var i,
 			type;
 
-		for (i = 0; i < EVENT_TYPES.length; i++) {
-			type = EVENT_TYPES[i];
+		for (i = 0; i < eventTypes.length; i++) {
+			type = eventTypes[i];
 
 			// only call the callback if the event is on the handler
 			if (handler['on' + type]) {
@@ -87,9 +88,10 @@ Box.DOMEventDelegate = (function() {
 	 * An object that manages events within a single DOM element.
 	 * @param {HTMLElement} element The DOM element to handle events for.
 	 * @param {Object} handler An object containing event handlers such as "onclick".
+	 * @param {string[]} [eventTypes] A list of event types to handle (events must bubble). Defaults to a common set of events.
 	 * @constructor
 	 */
-	function DOMEventDelegate(element, handler) {
+	function DOMEventDelegate(element, handler, eventTypes) {
 
 		/**
 		 * The DOM element that this object is handling events for.
@@ -103,6 +105,13 @@ Box.DOMEventDelegate = (function() {
 		 * @private
 		 */
 		this._handler = handler;
+
+		/**
+		 * List of event types to handle (make sure these events bubble!)
+		 * @type {string[]}
+		 * @private
+		 */
+		this._eventTypes = eventTypes || DEFAULT_EVENT_TYPES;
 
 		/**
 		 * Tracks event handlers whose this-value is bound to the correct
@@ -140,7 +149,7 @@ Box.DOMEventDelegate = (function() {
 		attachEvents: function() {
 			if (!this._attached) {
 
-				forEachEventType(this._handler, function(eventType) {
+				forEachEventType(this._eventTypes, this._handler, function(eventType) {
 					var that = this;
 
 					function handleEvent() {
@@ -161,7 +170,7 @@ Box.DOMEventDelegate = (function() {
 		 * @returns {void}
 		 */
 		detachEvents: function() {
-			forEachEventType(this._handler, function(eventType) {
+			forEachEventType(this._eventTypes, this._handler, function(eventType) {
 				Box.DOM.off(this.element, eventType, this._boundHandler[eventType]);
 			}, this);
 		}

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -145,6 +145,24 @@ describe('Box.Application', function() {
 				Box.Application.start(testModule);
 			});
 
+			it('should bind event handlers with globalConfig.eventTypes when called', function() {
+				var eventTypes = ['touchstart'];
+				Box.Application.init({
+					eventTypes: eventTypes
+				});
+
+				var domEventDelegateSpy = sandbox.spy(Box, 'DOMEventDelegate');
+				Box.Application.addModule('test', function() {
+					return {};
+				});
+
+				Box.Application.start(testModule);
+
+				assert.deepEqual(domEventDelegateSpy.getCall(0).args[2], eventTypes);
+
+				domEventDelegateSpy.restore();
+			});
+
 			it('should call init() behaviors in order they are defined and then the module when called', function() {
 				var moduleInitSpy = sandbox.spy(),
 					behaviorInitSpy = sandbox.spy(),

--- a/tests/dom-event-delegate-test.js
+++ b/tests/dom-event-delegate-test.js
@@ -125,6 +125,32 @@ describe('Box.DOMEventDelegate', function() {
 				click(testElement.firstChild);
 			});
 
+			it('should respond to custom events when a custom event type list is specified', function() {
+
+				delegate = new Box.DOMEventDelegate(testElement, {
+					ontouchstart: sandbox.mock()
+				}, ['touchstart']);
+
+				delegate.attachEvents();
+
+				var event = document.createEvent('Event');
+				event.initEvent('touchstart', true, true);
+
+				testElement.firstChild.dispatchEvent(event);
+			});
+
+			it('should respond only to custom events when a custom event type list is specified', function() {
+
+				delegate = new Box.DOMEventDelegate(testElement, {
+					onclick: sandbox.mock().never()
+				}, ['onsubmit']);
+
+				delegate.attachEvents();
+
+				click(testElement.firstChild);
+			});
+
+
 		});
 
 		describe('detachEvents()', function() {


### PR DESCRIPTION
Adds a new param to Box.Application.init() - eventTypes: [...events...]

fixes #146