### PR TITLE
Fixes constructor reference in instances of Box.Context and Box.TestServiceProvider (fixes #172)

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -25,6 +25,7 @@ Box.Context = (function() {
 	//-------------------------------------------------------------------------
 
 	Context.prototype = {
+		constructor: Context,
 
 		/**
 		 * Passthrough method to application that broadcasts messages.

--- a/lib/test-service-provider.js
+++ b/lib/test-service-provider.js
@@ -67,6 +67,7 @@
 	};
 
 	Box.TestServiceProvider.prototype = {
+		constructor: Box.TestServiceProvider,
 
 		/**
 		 * Will retrieve either a service stub (prioritized) or the real service. Returns null if neither exists.

--- a/tests/context-test.js
+++ b/tests/context-test.js
@@ -14,6 +14,14 @@ describe('Box.Context', function() {
 		sandbox.verifyAndRestore();
 	});
 
+	describe('new Box.Context', function(){
+		it('should have Box.Context as its constructor', function(){
+			var context = new Box.Context();
+
+			assert.strictEqual(context.constructor, Box.Context);
+		});
+	});
+
 	describe('broadcast()', function() {
 
 		it('should pass through to application when called', function() {

--- a/tests/test-service-provider-test.js
+++ b/tests/test-service-provider-test.js
@@ -22,6 +22,12 @@ describe('Box.TestServiceProvider', function() {
 
 	describe('new Box.TestServiceProvider', function() {
 
+		it('should have Box.TestServiceProvider as its constructor', function(){
+			testServiceProvider = new Box.TestServiceProvider();
+
+			assert.strictEqual(testServiceProvider.constructor, Box.TestServiceProvider);
+		});
+
 		it('should set this.stubs to serviceStubs when called', function() {
 			var serviceStub = {
 				bar: 'baz'


### PR DESCRIPTION
Fixes #172 

Added Box.TestServiceProvider as constructor property on prototype for Box.TestServiceProvider.
Added Box.Context as constructor property on prototype for Box.Context.
