### PR TITLE
Added new method to report console info messages in debug mode (#175)

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -835,6 +835,22 @@ Box.Application = (function() {
 			} else {
 				application.fire('warning', data);
 			}
+		},
+
+		/**
+		 * Display console info messages.
+		 * If in development mode, console.info is invoked.
+		 * @param {*} data A message string or arbitrary data
+		 * @returns {void}
+		 */
+		reportInfo: function(data) {
+			if (globalConfig.debug) {
+				// We grab console via getGlobal() so we can stub it out in tests
+				var globalConsole = this.getGlobal('console');
+				if (globalConsole && globalConsole.info) {
+					globalConsole.info(data);
+				}
+			}
 		}
 
 	});

--- a/lib/test-service-provider.js
+++ b/lib/test-service-provider.js
@@ -13,7 +13,7 @@
 	// function stubs that are automatically included on a TestServiceProvider
 	var APPLICATION_CONTEXT_STUBS = [
 		// Shared between Application and Context
-		'broadcast', 'getGlobalConfig', 'reportError', 'reportWarning',
+		'broadcast', 'getGlobalConfig', 'reportError', 'reportWarning', 'reportInfo',
 
 		// Application (only ones that should be called from a service)
 		'start', 'stop', 'startAll', 'stopAll', 'isStarted',

--- a/tests/application-test.js
+++ b/tests/application-test.js
@@ -1081,6 +1081,22 @@ describe('Box.Application', function() {
 
 		});
 
+		describe('reportInfo()', function() {
+
+			it('should do a `console.info` when in debug mode', function() {
+				Box.Application.init({
+					debug: true
+				});
+
+				sandbox.mock(Box.Application).expects('getGlobal').withArgs('console').returns({
+					info: sandbox.mock().withArgs('blah')
+				});
+
+				Box.Application.reportInfo('blah');
+			});
+
+		});
+
 	});
 
 });


### PR DESCRIPTION
I added the reportInfo method to display information messages when the debug mode is enabled.